### PR TITLE
OS agnostic code is now moved to nrfxlib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,8 +138,13 @@ endif
 OBJS += $(OSAL_DIR)/hw_if/hal/src/hpqm.o
 
 # Driver debugging
-# Use one of DBG/INF/ERR
-# ccflags-y += -DCONFIG_WIFI_NRF700X_LOG_LEVEL_DBG
+# Use one of DBG(4)/INF(3)/ERR(1)
+ccflags-y += -DCONFIG_WIFI_NRF700X_LOG_LEVEL=3
+
+# Scan only mode, disabled by default
+ccflags-y += -DCONFIG_NRF700X_SCAN_ONLY_MODE=0
+
+ccflags-y += -DCONFIG_NRF_WIFI_BEAMFORMING=1
 
 # Disable RAW scan results by default
 #ccflags-y += -DCONFIG_WIFI_MGMT_RAW_SCAN_RESULTS

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ifeq ($(LOW_POWER), 1)
 ccflags-y += -DCONFIG_NRF_WIFI_LOW_POWER
 endif
 
-OSAL_DIR	= ../nrf/drivers/wifi/nrf700x/osal
+OSAL_DIR	= ../nrfxlib/nrf_wifi
 ROOT_INC_DIR	= $(shell cd $(PWD); cd $(OSAL_DIR); pwd)
 LINUX_SHIM_INC_DIR = $(shell cd $(PWD); pwd)
 LINUX_SHIM_DIR = .

--- a/src/main.c
+++ b/src/main.c
@@ -622,6 +622,7 @@ nrf_wifi_fmac_dev_init_lnx(struct nrf_wifi_ctx_lnx *rpu_ctx_lnx)
 					sleep_type,
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 					NRF_WIFI_DEF_PHY_CALIB, op_band,
+					CONFIG_NRF_WIFI_BEAMFORMING,
 					&tx_pwr_ctrl_params,
 					&tx_pwr_ceil_params);
 #else
@@ -630,6 +631,7 @@ nrf_wifi_fmac_dev_init_lnx(struct nrf_wifi_ctx_lnx *rpu_ctx_lnx)
 					   sleep_type,
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 					   NRF_WIFI_DEF_PHY_CALIB, op_band,
+					   CONFIG_NRF_WIFI_BEAMFORMING,
 					   &tx_pwr_ctrl_params);
 #endif /* !CONFIG_NRF700X_RADIO_TEST */
 	if (status != NRF_WIFI_STATUS_SUCCESS) {

--- a/west.yml
+++ b/west.yml
@@ -8,7 +8,7 @@ manifest:
 
   projects:
     # TODO: Once west supports sparse checkout, we should use it here.
-    - name: nrf
+    - name: nrfxlib
       remote: ncs
-      repo-path: sdk-nrf
-      revision: bfb726d512545989ac1b64c0bc8694c3e5ff0b42
+      repo-path: sdk-nrfxlib
+      revision: 65ebc092adf57618e97a65872e4e7016bd94cc56


### PR DESCRIPTION
* Add nrfxlib to the west manifest
* Move OS agnostic code paths to nrfxlib