### PR TITLE
manifest: Pull external flash support changes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -11,4 +11,4 @@ manifest:
     - name: nrfxlib
       remote: ncs
       repo-path: sdk-nrfxlib
-      revision: 712a6aac342a70ebec5d84bb4b670241684fe405
+      revision: pull/1125/head


### PR DESCRIPTION
These are not needed for Linux, but the cleanups or preparation for external flash is still helpful.