### PR TITLE
manifest: Pull OS agnostic AP changes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -11,4 +11,4 @@ manifest:
     - name: nrfxlib
       remote: ncs
       repo-path: sdk-nrfxlib
-      revision: a086c1b1fc89c4326926580b84ba3745371a58f9
+      revision: pull/1151/head


### PR DESCRIPTION
These are common changes for AP mode, but primarily tested in Zephyr.