### PR TITLE
manifest: sdk-nrfxlib: Pull TX de-init crash fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -11,4 +11,4 @@ manifest:
     - name: nrfxlib
       remote: ncs
       repo-path: sdk-nrfxlib
-      revision: a086c1b1fc89c4326926580b84ba3745371a58f9
+      revision: pull/1164/head


### PR DESCRIPTION
This fixes a crash during traffic and iface down/up SNS test.