### PR TITLE
manifest: sdk-nrfxlib: Pull Osal header cleanup

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -11,4 +11,4 @@ manifest:
     - name: nrfxlib
       remote: ncs
       repo-path: sdk-nrfxlib
-      revision: a7dd3441ed55ee05234ed15c44c84243229c9876
+      revision: 82d06c118043d6f4dec965d3bf40abafc232735a


### PR DESCRIPTION
OSAL hdr cleanup changes to use internal hdrs [CAL-3923].