### PR TITLE
manifest: sdk-nrfxlib: Support for CSP package

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -11,4 +11,4 @@ manifest:
     - name: nrfxlib
       remote: ncs
       repo-path: sdk-nrfxlib
-      revision: 6c2f4ec7b8916e89cbce66cd0ad82df7642d6f78
+      revision: 622afe102c933c660d20ef811822a71d1c016845 


### PR DESCRIPTION
Modify the host driver to read the package type from the OTP memory and utilize this information to select RF parameters associated with voltage and temperature backoffs.