### PR TITLE
manifest: sdk-nrfxlib: Rename occurrences of bt*/ble* to sr*/SR*

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -11,4 +11,4 @@ manifest:
     - name: nrfxlib
       remote: ncs
       repo-path: sdk-nrfxlib
-      revision: 622afe102c933c660d20ef811822a71d1c016845 
+      revision: pull/1204/head 


### PR DESCRIPTION
SHEL-2395: Rename all occurrences of ble*/BLE*/bt*/BT* to sr*/SR* to have generic names in common code, to support coexistence with Short Range radios.