### PR TITLE
manifest: sdk-nrfxlib: Incorporate CSP related parameters in firmware

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -11,4 +11,4 @@ manifest:
     - name: nrfxlib
       remote: ncs
       repo-path: sdk-nrfxlib
-      revision: 622afe102c933c660d20ef811822a71d1c016845 
+      revision: pull/1213/head


### PR DESCRIPTION
[SHEL-2435/SHEL-2438]: Incorporate power backoff related changes for
CSP package which are dependent on voltage and temperature.
[SHEL-2310]: Support for CSP package in Host driver.